### PR TITLE
Add support for JSON and YAML output formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,9 @@ dependencies = [
  "env_logger",
  "git2",
  "log",
+ "serde",
+ "serde_json",
+ "serde_yaml",
  "time",
  "url",
 ]
@@ -437,6 +440,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,6 +661,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707d15895415db6628332b737c838b88c598522e4dc70647e59b72312924aebc"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,6 +737,7 @@ dependencies = [
  "itoa",
  "libc",
  "num_threads",
+ "serde",
  "time-macros",
 ]
 
@@ -777,6 +799,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -821,6 +844,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,8 @@ dialoguer = "0.10.1"
 env_logger = "0.9.0"
 git2 = { version = "0.14.4", features = ["vendored-openssl", "vendored-libgit2"] }
 log = "0.4.17"
-time = { version = "0.3.9", features = ["formatting", "macros"] }
-url = "2.2.2"
+serde = { version = "1.0.137", features = ["derive"] }
+serde_json = "1.0.81"
+serde_yaml = "0.8.24"
+time = { version = "0.3.9", features = ["formatting", "macros", "serde"] }
+url = {version = "2.2.2", features = ["serde"]}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,9 +71,7 @@ fn parse_format(input: &str) -> Result<Format> {
     let format = Format::from_str(input)?;
 
     match format {
-        Format::KeyValue => Ok(format),
-        Format::Json => return Err(anyhow!("JSON format not implemented")),
-        Format::Yaml => return Err(anyhow!("YAML format not implemented")),
+        Format::KeyValue | Format::Json | Format::Yaml => Ok(format),
         Format::Rdf => return Err(anyhow!("RDF format not implemented")),
     }
 }

--- a/src/format/key_value.rs
+++ b/src/format/key_value.rs
@@ -31,6 +31,15 @@ macro_rules! write_field {
             write_field!($f, $fmt, item);
         }
     };
+
+    // Write out an optional iterable field.
+    ( @optall, $f:ident, $fmt:literal, $field:expr ) => {
+        if let Some(field) = &$field {
+            for item in field {
+                write_field!($f, $fmt, item);
+            }
+        }
+    };
 }
 
 /// Write the document out to the provided writer.
@@ -43,10 +52,10 @@ pub fn write<W: Write>(mut w: W, doc: &Document) -> Result<()> {
     write_field!(w, "DocumentName: {}", doc.document_name);
     write_field!(w, "DocumentNamespace: {}", doc.document_namespace);
     write_field!(@opt, w, "ExternalDocumentRef: {}", doc.external_document_reference);
-    write_field!(@opt, w, "LicenseListVersion: {}", doc.license_list_version);
-    write_field!(@all, w, "Creator: {}", doc.creator);
-    write_field!(w, "Created: {}", doc.created);
-    write_field!(@opt, w, "CreatorComment: {}", doc.creator_comment);
+    write_field!(@opt, w, "LicenseListVersion: {}", doc.creation_info.license_list_version);
+    write_field!(@optall, w, "Creator: {}", doc.creation_info.creators);
+    write_field!(w, "Created: {}", doc.creation_info.created);
+    write_field!(@opt, w, "CreatorComment: {}", doc.creation_info.comment);
     write_field!(@opt, w, "DocumentComment: {}", doc.document_comment);
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,10 @@ fn run() -> Result<()> {
     let output_manager = OutputManager::new(&args, metadata.root()?);
 
     // Build the document.
-    let doc = document::build(&args, &output_manager.output_file_name())?;
+    let doc = document::build(
+        args.host_url()?.as_ref(),
+        &output_manager.output_file_name(),
+    )?;
 
     // Write the document to the output file.
     output_manager.write_document(doc)

--- a/src/output.rs
+++ b/src/output.rs
@@ -70,6 +70,8 @@ impl OutputManager {
         // Write the document out in the requested format.
         match self.format {
             Format::KeyValue => Ok(format::key_value::write(&mut writer, &doc)?),
+            Format::Json => Ok(serde_json::to_writer(writer, &doc)?),
+            Format::Yaml => Ok(serde_yaml::to_writer(writer, &doc)?),
             _ => Err(anyhow!("{} format not yet implemented", self.format)),
         }
     }


### PR DESCRIPTION
This PR adds support for JSON and YAML output support.

The specification for JSON/RDF/YAML differs from the tag:value format in a couple of ways that caused me to change some of the structs in `document.rs`.

1. different nesting. E.g creator information is nested beneath creationInfo for the former formats but not tag:value.
2. field names.

If `cargo-spdx` is going to support multiple formats then its internal structs should probably match the JSON/RDF/YAML representation to allow integration with serde, and since SPDX has a JSON schema the structs for the unimplemented parts of the specification can be generated automatically.