### PR TITLE
use Args::parse() to get better UX from clap

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,14 +19,6 @@ pub enum Args {
     Spdx(SpdxArgs),
 }
 
-impl Args {
-    /// Read arguments from the CLI.
-    pub fn read() -> Result<Self> {
-        log::info!(target: "cargo_spdx", "parsing cli arguments");
-        Ok(Args::try_parse()?)
-    }
-}
-
 // Use a Deref impl to avoid the rest of the codebase having to care
 // about the nesting structure required here.
 impl Deref for Args {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use crate::cli::Args;
 use crate::format::Format;
 use crate::output::OutputManager;
 use anyhow::Result;
+use clap::Parser;
 
 mod cargo;
 mod cli;
@@ -36,7 +37,7 @@ fn init() {
 fn run() -> Result<()> {
     // Load the CLI args and crate metadata, and then figure out where the SPDX file
     // will be written, setting up a manager to ensure we only write when conditions are met.
-    let args = Args::read()?;
+    let args = Args::parse();
     let metadata = CrateMetadata::load()?;
     let output_manager = OutputManager::new(&args, metadata.root()?);
 


### PR DESCRIPTION
This gives a better responses when users don't specify `-h` or don't pass in a valid argument combinartion.

E.g before this change, I get an error when running `cargo spdx -h`:

```bash
$ cargo spdx -h
error: cargo-spdx 0.1.0
Generate an SPDX SBOM for a crate

USAGE:
    cargo spdx [OPTIONS]

OPTIONS:
    -f, --format <FORMAT>        The output format to use: 'kv' (default), 'json', 'yaml', 'rdf'
    -F, --force                  Force the output, replacing any existing file with the same name
    -h, --help                   Print help information
    -H, --host-url <HOST_URL>    The URL where the SBOM will be hosted. Must be unique for each SBOM
    -n, --no-interact            Do not run interactively
    -o, --output <OUTPUT>        The path of the desired output file
    -V, --version                Print version information
```

After:
```bash
$ cargo spdx -h
cargo-spdx 0.1.0
Generate an SPDX SBOM for a crate

USAGE:
    cargo spdx [OPTIONS]

OPTIONS:
    -f, --format <FORMAT>        The output format to use: 'kv' (default), 'json', 'yaml', 'rdf'
    -F, --force                  Force the output, replacing any existing file with the same name
    -h, --help                   Print help information
    -H, --host-url <HOST_URL>    The URL where the SBOM will be hosted. Must be unique for each SBOM
    -n, --no-interact            Do not run interactively
    -o, --output <OUTPUT>        The path of the desired output file
    -V, --version                Print version information
```
Second one has color terminal support too.