### PR TITLE
add build subcommand produces SBOMs for cargo build produced binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "camino"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,15 +74,19 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
+ "clap-cargo",
  "derive_builder",
  "derive_more",
  "dialoguer",
  "env_logger",
  "git2",
+ "hex",
  "log",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha1",
+ "sha2",
  "time",
  "url",
 ]
@@ -124,6 +137,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-cargo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6b78b6a766ca6a8f83d4642a5eea9b43fa827fe7cb16efa7093402c393dafd3"
+dependencies = [
+ "cargo_metadata",
+ "clap",
+ "doc-comment",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +189,25 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5999502d32b9c48d492abe66392408144895020ec4709e549e840799f3bb74c0"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -257,6 +300,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +360,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "git2"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
 
 [[package]]
 name = "heck"
@@ -335,6 +404,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "humantime"
@@ -477,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "openssl-probe"
@@ -489,9 +564,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.21.0+1.1.1p"
+version = "111.22.0+1.1.1q"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0a8313729211913936f1b95ca47a5fc7f2e04cd658c115388287f8a8361008"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
 dependencies = [
  "cc",
 ]
@@ -581,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -592,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -662,14 +737,36 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707d15895415db6628332b737c838b88c598522e4dc70647e59b72312924aebc"
+checksum = "1ec0091e1f5aa338283ce049bd9dfefd55e1f168ac233e85c1ffe0038fb48cbe"
 dependencies = [
  "indexmap",
  "ryu",
  "serde",
  "yaml-rust",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -761,6 +858,12 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,18 @@ keywords = ["cli", "supply-chain", "sbom", "spdx", "cargo"]
 anyhow = "1.0.57"
 cargo_metadata = "0.15.0"
 clap = { version = "3.1.18", features = ["derive"] }
+clap-cargo = {version = "0.9.0", features =["cargo_metadata"]}
 derive_builder = "0.11.2"
 derive_more = "0.99.17"
 dialoguer = "0.10.1"
 env_logger = "0.9.0"
 git2 = { version = "0.14.4", features = ["vendored-openssl", "vendored-libgit2"] }
+hex = "0.4.3"
 log = "0.4.17"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 serde_yaml = "0.8.24"
+sha1 = "0.10.1"
+sha2 = "0.10.2"
 time = { version = "0.3.9", features = ["formatting", "macros", "serde"] }
 url = {version = "2.2.2", features = ["serde"]}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ __`cargo-spdx` is currently in development and not yet ready for use.__
 `cargo-spdx` provides a cargo subcommand to generate an
 [SPDX][spdx] Software Bill of Materials (SBOM) for a Rust crate.
 
+## Usage
+
+`cargo spdx` creates an SBOM for the current crate.
+
+`cargo spdx build` wraps `cargo build`, producing SBOMs for each produced binary.
+
+See `cargo spdx --help` for more detail.
+
 ## Contributing
 
 Anyone is welcome to contribute. You can find the list of open issues

--- a/src/build.rs
+++ b/src/build.rs
@@ -161,7 +161,6 @@ fn produce_sbom(
     host_url: &str,
     format: Format,
 ) -> Result<()> {
-    let files = Vec::new();
     let mut relationships = Vec::new();
 
     // Create file information
@@ -199,7 +198,7 @@ fn produce_sbom(
     );
     let output_manager = OutputManager::new(&spdx_path.into_std_path_buf(), true, format);
     let doc = document::builder(host_url, &output_manager.output_file_name())?
-        .files(files)
+        .files(vec![file])
         .packages(packages.values().cloned().collect())
         .relationships(relationships)
         .build()?;

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,0 +1,237 @@
+//! Implements `cargo spdx build` subcommand
+
+use crate::document::{self, File, Package, Relationship, RelationshipType};
+use crate::format::Format;
+use crate::output::OutputManager;
+use anyhow::Result;
+use cargo_metadata::camino::Utf8PathBuf;
+use cargo_metadata::{Artifact, Metadata, MetadataCommand, PackageId};
+use clap::Parser;
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::io::{BufRead, BufReader};
+use std::process::{ChildStdout, Command, Stdio};
+
+// Used for capturing the `cargo build` arguments we need to intercept
+#[derive(Debug, Parser)]
+#[clap(name = "build", ignore_errors = true)]
+struct CargoBuild {
+    #[clap(long)]
+    target: Option<String>,
+    #[clap(long)]
+    message_format: Option<String>,
+    // clap_cargo doesn't support -F or comma separated features
+    // https://github.com/crate-ci/clap-cargo/pull/33 fixes first
+    // TODO fix second with custom parser
+    #[clap(flatten)]
+    features: clap_cargo::Features,
+}
+
+// Stores packages and binaries identified from `cargo build`
+#[derive(Debug, Default)]
+struct CargoBuildInfo {
+    /// packages identified from cargo json messages
+    packages: HashMap<PackageId, Package>,
+    /// binaries identifed from cargo json messages
+    binaries: Vec<(Utf8PathBuf, PackageId)>,
+}
+
+/// Runs a `cargo build`, outputting an SBOM for each binary produced
+///
+/// # Arguments
+/// * `build_args` - Arguments that will be passed to `cargo build`
+///
+pub fn build(build_args: &[OsString], host_url: &str, format: Format) -> Result<()> {
+    // This function runs `cargo build` with json messages enabled, in order to detect produced binaries
+    // and identify crates used in build.
+
+    // cargo sets this for cargo subcommands, so use that when invoking cargo, if present
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let mut cargo_build_args: Vec<OsString> = vec!["build".to_string().into()];
+    cargo_build_args.extend(build_args.iter().cloned());
+
+    // cargo messages only give a package id for crates, we need cargo metadata to get more
+    // detail.
+    // Determine what features/target args need passing to cargo metadata by forwarding any relevant
+    // user specified `cargo build` args to `cargo metadata`.
+    // (We could probably just not filter-platform, and pass all features, as cargo
+    // messages tell us what was actually used in the build. But this future proofs
+    // against us using the feature information returned by cargo metadata.)
+    let mut metadata_cmd = MetadataCommand::new();
+    let CargoBuild {
+        features,
+        target,
+        message_format,
+    } = CargoBuild::try_parse_from(&cargo_build_args)?;
+    features.forward_metadata(&mut metadata_cmd);
+    if let Some(target) = target {
+        metadata_cmd.other_options(vec!["--filter-platform".to_string(), target]);
+    }
+    let metadata = metadata_cmd.exec()?;
+
+    // If the user specified a non-json message format for cargo, then exit as we won't
+    // be able to specify --message-format=json to cargo
+    if let Some(message_format) = &message_format {
+        if !message_format.starts_with("json") {
+            anyhow::bail!(
+                "--message-format must either be omittted or be set to one of the json options"
+            );
+        }
+    } else {
+        cargo_build_args.push("--message-format=json".to_string().into());
+    }
+
+    // Run `cargo build`
+    let mut child = Command::new(cargo)
+        .stderr(Stdio::inherit())
+        .stdout(Stdio::piped())
+        .args(cargo_build_args)
+        .spawn()?;
+
+    let stdout = child.stdout.take().unwrap();
+    let cargo_build_info = process_json_messages(stdout, message_format.is_some(), &metadata)?;
+
+    // Verify cargo build succeeds. If it fails, exit with the same exit code
+    let ecode = child.wait()?;
+    if !ecode.success() {
+        log::error!(target: "cargo_spdx", "cargo build failed");
+        std::process::exit(ecode.code().unwrap_or(1));
+    }
+
+    for (binary, package_id) in cargo_build_info.binaries {
+        produce_sbom(
+            binary,
+            &cargo_build_info.packages,
+            &package_id,
+            host_url,
+            format,
+        )?;
+    }
+    Ok(())
+}
+
+// Identify binaries and packages from cargo's json messages
+fn process_json_messages(
+    stdout: ChildStdout,
+    print_messages: bool,
+    metadata: &Metadata,
+) -> Result<CargoBuildInfo, anyhow::Error> {
+    let mut collector = CargoBuildInfo::default();
+
+    let reader = BufReader::new(stdout);
+    reader
+        .lines()
+        .filter_map(|line| {
+            line.and_then(|line| {
+                // If the user specified a message format arg, then
+                // print the message to stdout.
+                if print_messages {
+                    println!("{}", line);
+                }
+
+                Ok(serde_json::from_str(&line)?)
+            })
+            .ok()
+        })
+        .try_for_each::<_, Result<()>>(|artifact: Artifact| {
+            // Identify dependent packages
+            let package = &metadata[&artifact.package_id];
+            if !collector.packages.contains_key(&artifact.package_id) {
+                collector
+                    .packages
+                    .insert(artifact.package_id.clone(), package.into());
+            }
+
+            // Identify executables
+            // TODO also identify compiled libraries e.g dll/.so/.a
+            if let Some(executable) = artifact.executable {
+                collector.binaries.push((executable, artifact.package_id));
+            }
+
+            Ok(())
+        })?;
+    Ok(collector)
+}
+
+// Create SBOM for each binary and output it alongside the binary
+fn produce_sbom(
+    binary: cargo_metadata::camino::Utf8PathBuf,
+    packages: &HashMap<PackageId, Package>,
+    package_id: &PackageId,
+    host_url: &str,
+    format: Format,
+) -> Result<()> {
+    let files = Vec::new();
+    let mut relationships = Vec::new();
+
+    // Create file information
+    let file = File::try_from_binary(&binary)?;
+
+    // Indicate the crate the binary was generated from
+    relationships.push(Relationship {
+        comment: None,
+        related_spdx_element: packages.get(package_id).unwrap().spdxid.clone(),
+        relationship_type: RelationshipType::GeneratedFrom,
+        spdx_element_id: file.spdxid.clone(),
+    });
+
+    // Add all crates as dependencies of the binary
+    // (May include unused dependencies e.g as part of a workspace build that produces
+    // multiple binaries. Not obvious how to refine this outside of cargo
+    // without the user doing a build per binary)
+    relationships.extend(packages.values().map(|package| Relationship {
+        comment: None,
+        related_spdx_element: package.spdxid.clone(),
+        // Is this the best fit? Should the file indicate that it statically links the crate?
+        relationship_type: RelationshipType::DependsOn,
+        spdx_element_id: file.spdxid.clone(),
+    }));
+
+    // Create the SBOM and write it out
+    let mut spdx_path = binary;
+    spdx_path.set_extension(
+        format!(
+            "{}{}",
+            spdx_path.extension().unwrap_or_default(),
+            format.extension()
+        )
+        .trim_start_matches('.'),
+    );
+    let output_manager = OutputManager::new(&spdx_path.into_std_path_buf(), true, format);
+    let doc = document::builder(host_url, &output_manager.output_file_name())?
+        .files(files)
+        .packages(packages.values().cloned().collect())
+        .relationships(relationships)
+        .build()?;
+    output_manager.write_document(&doc)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::CargoBuild;
+
+    #[test]
+    fn test_cargo_build_arg_parsing() {
+        // Test there's no error when an arg not in CargoBuild is specified
+        let cargs = CargoBuild::try_parse_from([
+            "build",
+            "--no-default-features",
+            "--features",
+            "foo bar",
+            "--message-format=json",
+            "--target=x86_64-unknown-linux-musl",
+            "--release",
+        ])
+        .unwrap();
+        assert!(cargs.features.no_default_features);
+        assert_eq!(
+            cargs.features.features,
+            vec!["foo".to_string(), "bar".to_string()]
+        );
+        assert_eq!(cargs.message_format, Some("json".to_string()));
+        assert_eq!(cargs.target, Some("x86_64-unknown-linux-musl".to_string()));
+    }
+}

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,27 +1,18 @@
 //! Functions for interacting with `cargo-metadata`.
 
 use anyhow::{anyhow, Result};
-use cargo_metadata::{Metadata, MetadataCommand, Package};
+use cargo_metadata::{Metadata, Package};
 
-/// Metadata of the crate being documented.
-pub struct CrateMetadata(
-    /// The metadata.
-    Metadata,
-);
+pub trait MetadataExt<'a> {
+    fn root(&'a self) -> Result<&'a Package>;
+}
 
-impl CrateMetadata {
-    /// Load crate metadata.
-    pub fn load() -> Result<Self> {
-        log::info!(target: "cargo_spdx", "loading crate metadata");
-        Ok(CrateMetadata(MetadataCommand::new().exec()?))
-    }
-
+impl<'a> MetadataExt<'a> for Metadata {
     /// Extract the root package info from the crate metadata.
-    pub fn root(&self) -> Result<&Package> {
-        self.0
-            .resolve
+    fn root(&'a self) -> Result<&'a Package> {
+        self.resolve
             .as_ref()
-            .and_then(|r| r.root.as_ref().map(|r| &self.0[r]))
+            .and_then(|r| r.root.as_ref().map(|r| &self[r]))
             .ok_or_else(|| anyhow!("no root found"))
     }
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -2,23 +2,36 @@
 
 use crate::git::get_current_user;
 use anyhow::Result;
+use cargo_metadata::camino::Utf8PathBuf;
 use derive_builder::Builder;
 use derive_more::{Display, From};
-use serde::{Serialize, Serializer};
-use std::fmt::{Display, Formatter};
+use serde::{Deserialize, Serialize, Serializer};
+use sha1::{Digest, Sha1};
+use sha2::Sha256;
+use std::{
+    fmt::{Display, Formatter},
+    fs, io,
+};
 use time::{format_description, OffsetDateTime};
 use url::Url;
 
+pub const NOASSERTION: &str = "NOASSERTION";
+
 /// Build a new SPDX document based on collected information.
 pub fn build(host_url: &str, output_file_name: &str) -> Result<Document> {
+    Ok(builder(host_url, output_file_name)?.build()?)
+}
+
+/// Build a new SPDX document based on collected information.
+pub fn builder(host_url: &str, output_file_name: &str) -> Result<DocumentBuilder> {
     log::info!(target: "cargo_spdx", "building the document");
 
-    // Construct the document.
-    Ok(DocumentBuilder::default()
+    let mut builder = DocumentBuilder::default();
+    builder
         .document_name(output_file_name)
         .try_document_namespace(host_url)?
-        .creation_info(get_creation_info()?)
-        .build()?)
+        .creation_info(get_creation_info()?);
+    Ok(builder)
 }
 
 /// Identify the creator(s) of the SBOM.
@@ -93,6 +106,21 @@ pub struct Document {
     /// information for forward and backward compatibility for processing tools.
     #[serde(rename = "creationInfo")]
     pub creation_info: CreationInfo,
+
+    /// Packages referenced in the SPDX document
+    #[builder(setter(strip_option), default)]
+    #[serde(rename = "packages")]
+    pub packages: Option<Vec<Package>>,
+
+    /// Files referenced in the SPDX document
+    #[serde(rename = "files", skip_serializing_if = "Option::is_none")]
+    #[builder(setter(strip_option), default)]
+    pub files: Option<Vec<File>>,
+
+    /// Relationships referenced in the SPDX document
+    #[serde(rename = "relationships", skip_serializing_if = "Option::is_none")]
+    #[builder(setter(strip_option), default)]
+    pub relationships: Option<Vec<Relationship>>,
 }
 
 /// One instance is required for each SPDX file produced. It provides the necessary
@@ -275,4 +303,858 @@ impl Display for Created {
 
         write!(f, "{}", repr)
     }
+}
+
+impl From<&cargo_metadata::Package> for Package {
+    fn from(package: &cargo_metadata::Package) -> Self {
+        Package {
+            name: package.name.to_string(),
+            spdxid: format!("SPDXRef-{}-{}", package.name, package.version),
+            version_info: Some(package.version.to_string()),
+            package_file_name: None,
+            supplier: None,
+            originator: None,
+            download_location: NOASSERTION.to_string(),
+            files_analyzed: None,
+            package_verification_code: None,
+            checksums: None,
+            homepage: package.homepage.clone(),
+            source_info: None,
+            license_concluded: NOASSERTION.to_string(),
+            license_declared: NOASSERTION.to_string(),
+            copyright_text: NOASSERTION.to_string(),
+            description: None,
+            comment: None,
+            external_refs: if package.source.is_some() {
+                Some(vec![ExternalRef {
+                    reference_category: ReferenceCategory::PackageManager,
+                    reference_type: "purl".to_string(),
+                    reference_locator: format!("pkg:cargo/{}@{}", package.name, package.version),
+                    comment: None,
+                }])
+            } else {
+                None
+            },
+            annotations: None,
+            attribution_texts: None,
+            has_files: None,
+            license_comments: None,
+            license_info_from_files: None,
+            summary: None,
+        }
+    }
+}
+
+/// An Annotation is a comment on an SpdxItem by an agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileAnnotation {
+    /// Identify when the comment was made. This is to be specified according to the combined
+    /// date and time in the UTC format, as specified in the ISO 8601 standard.
+    #[serde(rename = "annotationDate")]
+    pub annotation_date: String,
+
+    /// Type of the annotation.
+    #[serde(rename = "annotationType")]
+    pub annotation_type: AnnotationType,
+
+    /// This field identifies the person, organization or tool that has commented on a file,
+    /// package, or the entire document.
+    #[serde(rename = "annotator")]
+    pub annotator: String,
+
+    #[serde(rename = "comment")]
+    pub comment: String,
+}
+
+/// A Checksum is value that allows the contents of a file to be authenticated. Even small
+/// changes to the content of the file will change its checksum. This class allows the
+/// results of a variety of checksum and cryptographic message digest algorithms to be
+/// represented.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileChecksum {
+    /// Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the
+    /// only supported algorithm. It is anticipated that other algorithms will be supported at a
+    /// later time.
+    #[serde(rename = "algorithm")]
+    pub algorithm: Algorithm,
+
+    /// The checksumValue property provides a lower case hexidecimal encoded digest value
+    /// produced using a specific algorithm.
+    #[serde(rename = "checksumValue")]
+    pub checksum_value: String,
+}
+
+/// An ExtractedLicensingInfo represents a license or licensing notice that was found in the
+/// package. Any license text that is recognized as a license may be represented as a License
+/// rather than an ExtractedLicensingInfo.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HasExtractedLicensingInfo {
+    #[serde(rename = "comment", skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+
+    /// Cross Reference Detail for a license SeeAlso URL
+    #[serde(rename = "crossRefs", skip_serializing_if = "Option::is_none")]
+    pub cross_refs: Option<Vec<CrossRef>>,
+
+    /// Verbatim license or licensing notice text that was discovered.
+    #[serde(rename = "extractedText")]
+    pub extracted_text: String,
+
+    /// A human readable short form license identifier for a license. The license ID is iether on
+    /// the standard license oist or the form "LicenseRef-"[idString] where [idString] is a
+    /// unique string containing letters, numbers, ".", "-" or "+".
+    #[serde(rename = "licenseId")]
+    pub license_id: String,
+
+    /// Identify name of this SpdxElement.
+    #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    #[serde(rename = "seeAlsos", skip_serializing_if = "Option::is_none")]
+    pub see_alsos: Option<Vec<String>>,
+}
+
+/// Cross reference details for the a URL reference
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CrossRef {
+    /// Indicate a URL is still a live accessible location on the public internet
+    #[serde(rename = "isLive", skip_serializing_if = "Option::is_none")]
+    pub is_live: Option<bool>,
+
+    /// True if the URL is a valid well formed URL
+    #[serde(rename = "isValid", skip_serializing_if = "Option::is_none")]
+    pub is_valid: Option<bool>,
+
+    /// True if the License SeeAlso URL points to a Wayback archive
+    #[serde(rename = "isWayBackLink", skip_serializing_if = "Option::is_none")]
+    pub is_way_back_link: Option<bool>,
+
+    /// Status of a License List SeeAlso URL reference if it refers to a website that matches the
+    /// license text.
+    #[serde(rename = "match", skip_serializing_if = "Option::is_none")]
+    pub cross_ref_match: Option<String>,
+
+    /// The ordinal order of this element within a list
+    #[serde(rename = "order", skip_serializing_if = "Option::is_none")]
+    pub order: Option<i64>,
+
+    /// Timestamp
+    #[serde(rename = "timestamp", skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+
+    /// URL Reference
+    #[serde(rename = "url")]
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Package {
+    /// Provide additional information about an SpdxElement.
+    #[serde(rename = "annotations", skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<Vec<PackageAnnotation>>,
+
+    /// This field provides a place for the SPDX data creator to record acknowledgements that may
+    /// be required to be communicated in some contexts. This is not meant to include theactual
+    /// complete license text (see licenseConculded and licenseDeclared), and may or may not
+    /// include copyright notices (see also copyrightText). The SPDX data creator may use this
+    /// field to record other acknowledgements, such as particular clauses from license texts,
+    /// which may be necessary or desirable to reproduce.
+    #[serde(rename = "attributionTexts", skip_serializing_if = "Option::is_none")]
+    pub attribution_texts: Option<Vec<String>>,
+
+    /// The checksum property provides a mechanism that can be used to verify that the contents
+    /// of a File or Package have not changed.
+    #[serde(rename = "checksums", skip_serializing_if = "Option::is_none")]
+    pub checksums: Option<Vec<PackageChecksum>>,
+
+    #[serde(rename = "comment", skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+
+    /// The text of copyright declarations recited in the Package or File.
+    #[serde(rename = "copyrightText")]
+    pub copyright_text: String,
+
+    /// Provides a detailed description of the package.
+    #[serde(rename = "description", skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// The URI at which this package is available for download. Private (i.e., not publicly
+    /// reachable) URIs are acceptable as values of this property. The values
+    /// http://spdx.org/rdf/terms#none and http://spdx.org/rdf/terms#noassertion may be used to
+    /// specify that the package is not downloadable or that no attempt was made to determine its
+    /// download location, respectively.
+    #[serde(rename = "downloadLocation")]
+    pub download_location: String,
+
+    /// An External Reference allows a Package to reference an external source of additional
+    /// information, metadata, enumerations, asset identifiers, or downloadable content believed
+    /// to be relevant to the Package.
+    #[serde(rename = "externalRefs", skip_serializing_if = "Option::is_none")]
+    pub external_refs: Option<Vec<ExternalRef>>,
+
+    /// Indicates whether the file content of this package has been available for or subjected to
+    /// analysis when creating the SPDX document. If false indicates packages that represent
+    /// metadata or URI references to a project, product, artifact, distribution or a component.
+    /// If set to false, the package must not contain any files.
+    #[serde(rename = "filesAnalyzed", skip_serializing_if = "Option::is_none")]
+    pub files_analyzed: Option<bool>,
+
+    /// Indicates that a particular file belongs to a package.
+    #[serde(rename = "hasFiles", skip_serializing_if = "Option::is_none")]
+    pub has_files: Option<Vec<String>>,
+
+    #[serde(rename = "homepage", skip_serializing_if = "Option::is_none")]
+    pub homepage: Option<String>,
+
+    /// The licenseComments property allows the preparer of the SPDX document to describe why the
+    /// licensing in spdx:licenseConcluded was chosen.
+    #[serde(rename = "licenseComments", skip_serializing_if = "Option::is_none")]
+    pub license_comments: Option<String>,
+
+    /// License expression for licenseConcluded.  The licensing that the preparer of this SPDX
+    /// document has concluded, based on the evidence, actually applies to the package.
+    #[serde(rename = "licenseConcluded")]
+    pub license_concluded: String,
+
+    /// License expression for licenseDeclared.  The licensing that the creators of the software
+    /// in the package, or the packager, have declared. Declarations by the original software
+    /// creator should be preferred, if they exist.
+    #[serde(rename = "licenseDeclared")]
+    pub license_declared: String,
+
+    /// The licensing information that was discovered directly within the package. There will be
+    /// an instance of this property for each distinct value of alllicenseInfoInFile properties
+    /// of all files contained in the package.
+    #[serde(
+        rename = "licenseInfoFromFiles",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub license_info_from_files: Option<Vec<String>>,
+
+    /// Identify name of this SpdxElement.
+    #[serde(rename = "name")]
+    pub name: String,
+
+    /// The name and, optionally, contact information of the person or organization that
+    /// originally created the package. Values of this property must conform to the agent and
+    /// tool syntax.
+    #[serde(rename = "originator", skip_serializing_if = "Option::is_none")]
+    pub originator: Option<String>,
+
+    /// The base name of the package file name. For example, zlib-1.2.5.tar.gz.
+    #[serde(rename = "packageFileName", skip_serializing_if = "Option::is_none")]
+    pub package_file_name: Option<String>,
+
+    /// A manifest based verification code (the algorithm is defined in section 4.7 of the full
+    /// specification) of the SPDX Item. This allows consumers of this data and/or database to
+    /// determine if an SPDX item they have in hand is identical to the SPDX item from which the
+    /// data was produced. This algorithm works even if the SPDX document is included in the SPDX
+    /// item.
+    #[serde(
+        rename = "packageVerificationCode",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub package_verification_code: Option<PackageVerificationCode>,
+
+    /// Allows the producer(s) of the SPDX document to describe how the package was acquired
+    /// and/or changed from the original source.
+    #[serde(rename = "sourceInfo", skip_serializing_if = "Option::is_none")]
+    pub source_info: Option<String>,
+
+    /// Uniquely identify any element in an SPDX document which may be referenced by other
+    /// elements.
+    #[serde(rename = "SPDXID")]
+    pub spdxid: String,
+
+    /// Provides a short description of the package.
+    #[serde(rename = "summary", skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    /// The name and, optionally, contact information of the person or organization who was the
+    /// immediate supplier of this package to the recipient. The supplier may be different than
+    /// originator when the software has been repackaged. Values of this property must conform to
+    /// the agent and tool syntax.
+    #[serde(rename = "supplier", skip_serializing_if = "Option::is_none")]
+    pub supplier: Option<String>,
+
+    /// Provides an indication of the version of the package that is described by this
+    /// SpdxDocument.
+    #[serde(rename = "versionInfo", skip_serializing_if = "Option::is_none")]
+    pub version_info: Option<String>,
+}
+
+/// An Annotation is a comment on an SpdxItem by an agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PackageAnnotation {
+    /// Identify when the comment was made. This is to be specified according to the combined
+    /// date and time in the UTC format, as specified in the ISO 8601 standard.
+    #[serde(rename = "annotationDate")]
+    pub annotation_date: String,
+
+    /// Type of the annotation.
+    #[serde(rename = "annotationType")]
+    pub annotation_type: AnnotationType,
+
+    /// This field identifies the person, organization or tool that has commented on a file,
+    /// package, or the entire document.
+    #[serde(rename = "annotator")]
+    pub annotator: String,
+
+    #[serde(rename = "comment")]
+    pub comment: String,
+}
+
+/// A Checksum is value that allows the contents of a file to be authenticated. Even small
+/// changes to the content of the file will change its checksum. This class allows the
+/// results of a variety of checksum and cryptographic message digest algorithms to be
+/// represented.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PackageChecksum {
+    /// Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the
+    /// only supported algorithm. It is anticipated that other algorithms will be supported at a
+    /// later time.
+    #[serde(rename = "algorithm")]
+    pub algorithm: Algorithm,
+
+    /// The checksumValue property provides a lower case hexidecimal encoded digest value
+    /// produced using a specific algorithm.
+    #[serde(rename = "checksumValue")]
+    pub checksum_value: String,
+}
+
+/// An External Reference allows a Package to reference an external source of additional
+/// information, metadata, enumerations, asset identifiers, or downloadable content believed
+/// to be relevant to the Package.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalRef {
+    #[serde(rename = "comment", skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+
+    /// Category for the external reference
+    #[serde(rename = "referenceCategory")]
+    pub reference_category: ReferenceCategory,
+
+    /// The unique string with no spaces necessary to access the package-specific information,
+    /// metadata, or content within the target location. The format of the locator is subject to
+    /// constraints defined by the <type>.
+    #[serde(rename = "referenceLocator")]
+    pub reference_locator: String,
+
+    /// Type of the external reference. These are definined in an appendix in the SPDX
+    /// specification.
+    #[serde(rename = "referenceType")]
+    pub reference_type: String,
+}
+
+/// A manifest based verification code (the algorithm is defined in section 4.7 of the full
+/// specification) of the SPDX Item. This allows consumers of this data and/or database to
+/// determine if an SPDX item they have in hand is identical to the SPDX item from which the
+/// data was produced. This algorithm works even if the SPDX document is included in the SPDX
+/// item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PackageVerificationCode {
+    /// A file that was excluded when calculating the package verification code. This is usually
+    /// a file containing SPDX data regarding the package. If a package contains more than one
+    /// SPDX file all SPDX files must be excluded from the package verification code. If this is
+    /// not done it would be impossible to correctly calculate the verification codes in both
+    /// files.
+    #[serde(
+        rename = "packageVerificationCodeExcludedFiles",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub package_verification_code_excluded_files: Option<Vec<String>>,
+
+    /// The actual package verification code as a hex encoded value.
+    #[serde(rename = "packageVerificationCodeValue")]
+    pub package_verification_code_value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Relationship {
+    #[serde(rename = "comment", skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+
+    /// SPDX ID for SpdxElement.  A related SpdxElement.
+    #[serde(rename = "relatedSpdxElement")]
+    pub related_spdx_element: String,
+
+    /// Describes the type of relationship between two SPDX elements.
+    #[serde(rename = "relationshipType")]
+    pub relationship_type: RelationshipType,
+
+    /// Id to which the SPDX element is related
+    #[serde(rename = "spdxElementId")]
+    pub spdx_element_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Reviewed {
+    #[serde(rename = "comment", skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+
+    /// The date and time at which the SpdxDocument was reviewed. This value must be in UTC and
+    /// have 'Z' as its timezone indicator.
+    #[serde(rename = "reviewDate")]
+    pub review_date: String,
+
+    /// The name and, optionally, contact information of the person who performed the review.
+    /// Values of this property must conform to the agent and tool syntax.
+    #[serde(rename = "reviewer", skip_serializing_if = "Option::is_none")]
+    pub reviewer: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Snippet {
+    /// Provide additional information about an SpdxElement.
+    #[serde(rename = "annotations", skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<Vec<SnippetAnnotation>>,
+
+    /// This field provides a place for the SPDX data creator to record acknowledgements that may
+    /// be required to be communicated in some contexts. This is not meant to include theactual
+    /// complete license text (see licenseConculded and licenseDeclared), and may or may not
+    /// include copyright notices (see also copyrightText). The SPDX data creator may use this
+    /// field to record other acknowledgements, such as particular clauses from license texts,
+    /// which may be necessary or desirable to reproduce.
+    #[serde(rename = "attributionTexts", skip_serializing_if = "Option::is_none")]
+    pub attribution_texts: Option<Vec<String>>,
+
+    #[serde(rename = "comment", skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+
+    /// The text of copyright declarations recited in the Package or File.
+    #[serde(rename = "copyrightText")]
+    pub copyright_text: String,
+
+    /// The licenseComments property allows the preparer of the SPDX document to describe why the
+    /// licensing in spdx:licenseConcluded was chosen.
+    #[serde(rename = "licenseComments", skip_serializing_if = "Option::is_none")]
+    pub license_comments: Option<String>,
+
+    /// License expression for licenseConcluded.  The licensing that the preparer of this SPDX
+    /// document has concluded, based on the evidence, actually applies to the package.
+    #[serde(rename = "licenseConcluded")]
+    pub license_concluded: String,
+
+    /// Licensing information that was discovered directly in the subject snippet. This is also
+    /// considered a declared license for the snippet.
+    #[serde(
+        rename = "licenseInfoInSnippets",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub license_info_in_snippets: Option<Vec<String>>,
+
+    /// Identify name of this SpdxElement.
+    #[serde(rename = "name")]
+    pub name: String,
+
+    /// This field defines the byte range in the original host file (in X.2) that the snippet
+    /// information applies to
+    #[serde(rename = "ranges", skip_serializing_if = "Option::is_none")]
+    pub ranges: Option<Vec<Range>>,
+
+    /// SPDX ID for File.  File containing the SPDX element (e.g. the file contaning a snippet).
+    #[serde(rename = "snippetFromFile")]
+    pub snippet_from_file: String,
+
+    /// Uniquely identify any element in an SPDX document which may be referenced by other
+    /// elements.
+    #[serde(rename = "SPDXID")]
+    pub spdxid: String,
+}
+
+/// An Annotation is a comment on an SpdxItem by an agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnippetAnnotation {
+    /// Identify when the comment was made. This is to be specified according to the combined
+    /// date and time in the UTC format, as specified in the ISO 8601 standard.
+    #[serde(rename = "annotationDate")]
+    pub annotation_date: String,
+
+    /// Type of the annotation.
+    #[serde(rename = "annotationType")]
+    pub annotation_type: AnnotationType,
+
+    /// This field identifies the person, organization or tool that has commented on a file,
+    /// package, or the entire document.
+    #[serde(rename = "annotator")]
+    pub annotator: String,
+
+    #[serde(rename = "comment")]
+    pub comment: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Range {
+    #[serde(rename = "endPointer")]
+    pub end_pointer: EndPointer,
+
+    #[serde(rename = "startPointer")]
+    pub start_pointer: StartPointer,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EndPointer {
+    /// line number offset in the file
+    #[serde(rename = "lineNumber", skip_serializing_if = "Option::is_none")]
+    pub line_number: Option<i64>,
+
+    /// Byte offset in the file
+    #[serde(rename = "offset", skip_serializing_if = "Option::is_none")]
+    pub offset: Option<i64>,
+
+    /// SPDX ID for File
+    #[serde(rename = "reference")]
+    pub reference: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StartPointer {
+    /// line number offset in the file
+    #[serde(rename = "lineNumber", skip_serializing_if = "Option::is_none")]
+    pub line_number: Option<i64>,
+
+    /// Byte offset in the file
+    #[serde(rename = "offset", skip_serializing_if = "Option::is_none")]
+    pub offset: Option<i64>,
+
+    /// SPDX ID for File
+    #[serde(rename = "reference")]
+    pub reference: String,
+}
+
+/// Type of the annotation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum AnnotationType {
+    #[serde(rename = "OTHER")]
+    Other,
+
+    #[serde(rename = "REVIEW")]
+    Review,
+}
+
+/// Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the
+/// only supported algorithm. It is anticipated that other algorithms will be supported at a
+/// later time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Algorithm {
+    #[serde(rename = "MD2")]
+    Md2,
+
+    #[serde(rename = "MD4")]
+    Md4,
+
+    #[serde(rename = "MD5")]
+    Md5,
+
+    #[serde(rename = "MD6")]
+    Md6,
+
+    #[serde(rename = "SHA1")]
+    Sha1,
+
+    #[serde(rename = "SHA224")]
+    Sha224,
+
+    #[serde(rename = "SHA256")]
+    Sha256,
+
+    #[serde(rename = "SHA384")]
+    Sha384,
+
+    #[serde(rename = "SHA512")]
+    Sha512,
+}
+
+/// The type of the file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FileType {
+    #[serde(rename = "APPLICATION")]
+    Application,
+
+    #[serde(rename = "ARCHIVE")]
+    Archive,
+
+    #[serde(rename = "AUDIO")]
+    Audio,
+
+    #[serde(rename = "BINARY")]
+    Binary,
+
+    #[serde(rename = "DOCUMENTATION")]
+    Documentation,
+
+    #[serde(rename = "IMAGE")]
+    Image,
+
+    #[serde(rename = "OTHER")]
+    Other,
+
+    #[serde(rename = "SOURCE")]
+    Source,
+
+    #[serde(rename = "SPDX")]
+    Spdx,
+
+    #[serde(rename = "TEXT")]
+    Text,
+
+    #[serde(rename = "VIDEO")]
+    Video,
+}
+
+/// Category for the external reference
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ReferenceCategory {
+    #[serde(rename = "OTHER")]
+    Other,
+
+    #[serde(rename = "PACKAGE_MANAGER")]
+    PackageManager,
+
+    #[serde(rename = "SECURITY")]
+    Security,
+}
+
+/// Describes the type of relationship between two SPDX elements.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum RelationshipType {
+    #[serde(rename = "ANCESTOR_OF")]
+    AncestorOf,
+
+    #[serde(rename = "BUILD_DEPENDENCY_OF")]
+    BuildDependencyOf,
+
+    #[serde(rename = "BUILD_TOOL_OF")]
+    BuildToolOf,
+
+    #[serde(rename = "CONTAINED_BY")]
+    ContainedBy,
+
+    #[serde(rename = "CONTAINS")]
+    Contains,
+
+    #[serde(rename = "COPY_OF")]
+    CopyOf,
+
+    #[serde(rename = "DATA_FILE_OF")]
+    DataFileOf,
+
+    #[serde(rename = "DEPENDENCY_MANIFEST_OF")]
+    DependencyManifestOf,
+
+    #[serde(rename = "DEPENDENCY_OF")]
+    DependencyOf,
+
+    #[serde(rename = "DEPENDS_ON")]
+    DependsOn,
+
+    #[serde(rename = "DESCENDANT_OF")]
+    DescendantOf,
+
+    #[serde(rename = "DESCRIBED_BY")]
+    DescribedBy,
+
+    #[serde(rename = "DESCRIBES")]
+    Describes,
+
+    #[serde(rename = "DEV_DEPENDENCY_OF")]
+    DevDependencyOf,
+
+    #[serde(rename = "DEV_TOOL_OF")]
+    DevToolOf,
+
+    #[serde(rename = "DISTRIBUTION_ARTIFACT")]
+    DistributionArtifact,
+
+    #[serde(rename = "DOCUMENTATION_OF")]
+    DocumentationOf,
+
+    #[serde(rename = "DYNAMIC_LINK")]
+    DynamicLink,
+
+    #[serde(rename = "EXAMPLE_OF")]
+    ExampleOf,
+
+    #[serde(rename = "EXPANDED_FROM_ARCHIVE")]
+    ExpandedFromArchive,
+
+    #[serde(rename = "FILE_ADDED")]
+    FileAdded,
+
+    #[serde(rename = "FILE_DELETED")]
+    FileDeleted,
+
+    #[serde(rename = "FILE_MODIFIED")]
+    FileModified,
+
+    #[serde(rename = "GENERATED_FROM")]
+    GeneratedFrom,
+
+    #[serde(rename = "GENERATES")]
+    Generates,
+
+    #[serde(rename = "HAS_PREREQUISITE")]
+    HasPrerequisite,
+
+    #[serde(rename = "METAFILE_OF")]
+    MetafileOf,
+
+    #[serde(rename = "OPTIONAL_COMPONENT_OF")]
+    OptionalComponentOf,
+
+    #[serde(rename = "OPTIONAL_DEPENDENCY_OF")]
+    OptionalDependencyOf,
+
+    #[serde(rename = "OTHER")]
+    Other,
+
+    #[serde(rename = "PACKAGE_OF")]
+    PackageOf,
+
+    #[serde(rename = "PATCH_APPLIED")]
+    PatchApplied,
+
+    #[serde(rename = "PATCH_FOR")]
+    PatchFor,
+
+    #[serde(rename = "PREREQUISITE_FOR")]
+    PrerequisiteFor,
+
+    #[serde(rename = "PROVIDED_DEPENDENCY_OF")]
+    ProvidedDependencyOf,
+
+    #[serde(rename = "RUNTIME_DEPENDENCY_OF")]
+    RuntimeDependencyOf,
+
+    #[serde(rename = "STATIC_LINK")]
+    StaticLink,
+
+    #[serde(rename = "TEST_CASE_OF")]
+    TestCaseOf,
+
+    #[serde(rename = "TEST_DEPENDENCY_OF")]
+    TestDependencyOf,
+
+    #[serde(rename = "TEST_OF")]
+    TestOf,
+
+    #[serde(rename = "TEST_TOOL_OF")]
+    TestToolOf,
+
+    #[serde(rename = "VARIANT_OF")]
+    VariantOf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct File {
+    /// Provide additional information about an SpdxElement.
+    #[serde(rename = "annotations", skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<Vec<FileAnnotation>>,
+
+    /// This field provides a place for the SPDX data creator to record acknowledgements that may
+    /// be required to be communicated in some contexts. This is not meant to include theactual
+    /// complete license text (see licenseConculded and licenseDeclared), and may or may not
+    /// include copyright notices (see also copyrightText). The SPDX data creator may use this
+    /// field to record other acknowledgements, such as particular clauses from license texts,
+    /// which may be necessary or desirable to reproduce.
+    #[serde(rename = "attributionTexts", skip_serializing_if = "Option::is_none")]
+    pub attribution_texts: Option<Vec<String>>,
+
+    /// The checksum property provides a mechanism that can be used to verify that the contents
+    /// of a File or Package have not changed.
+    #[serde(rename = "checksums", skip_serializing_if = "Option::is_none")]
+    pub checksums: Option<Vec<FileChecksum>>,
+
+    #[serde(rename = "comment", skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+
+    /// The text of copyright declarations recited in the Package or File.
+    #[serde(rename = "copyrightText")]
+    pub copyright_text: String,
+
+    /// This field provides a place for the SPDX file creator to record file contributors.
+    /// Contributors could include names of copyright holders and/or authors who may not be
+    /// copyright holders yet contributed to the file content.
+    #[serde(rename = "fileContributors", skip_serializing_if = "Option::is_none")]
+    pub file_contributors: Option<Vec<String>>,
+
+    #[serde(rename = "fileDependencies", skip_serializing_if = "Option::is_none")]
+    pub file_dependencies: Option<Vec<String>>,
+
+    /// The name of the file relative to the root of the package.
+    #[serde(rename = "fileName")]
+    pub file_name: String,
+
+    /// The type of the file.
+    #[serde(rename = "fileTypes", skip_serializing_if = "Option::is_none")]
+    pub file_types: Option<Vec<FileType>>,
+
+    /// The licenseComments property allows the preparer of the SPDX document to describe why the
+    /// licensing in spdx:licenseConcluded was chosen.
+    #[serde(rename = "licenseComments", skip_serializing_if = "Option::is_none")]
+    pub license_comments: Option<String>,
+
+    /// License expression for licenseConcluded.  The licensing that the preparer of this SPDX
+    /// document has concluded, based on the evidence, actually applies to the package.
+    #[serde(rename = "licenseConcluded")]
+    pub license_concluded: String,
+
+    /// Licensing information that was discovered directly in the subject file. This is also
+    /// considered a declared license for the file.
+    #[serde(rename = "licenseInfoInFiles", skip_serializing_if = "Option::is_none")]
+    pub license_info_in_files: Option<Vec<String>>,
+
+    /// This field provides a place for the SPDX file creator to record potential legal notices
+    /// found in the file. This may or may not include copyright statements.
+    #[serde(rename = "noticeText", skip_serializing_if = "Option::is_none")]
+    pub notice_text: Option<String>,
+
+    /// Uniquely identify any element in an SPDX document which may be referenced by other
+    /// elements.
+    #[serde(rename = "SPDXID")]
+    pub spdxid: String,
+}
+
+impl File {
+    pub fn try_from_binary(path: &Utf8PathBuf) -> Result<File> {
+        let file_name = path.file_name().unwrap();
+        let spdxid = format!("SPDXRef-File-{}", file_name);
+        Ok(File {
+            annotations: None,
+            attribution_texts: None,
+            checksums: Some(calculate_checksums(path)?),
+            comment: None,
+            copyright_text: NOASSERTION.to_string(),
+            file_contributors: None,
+            file_dependencies: None,
+            file_name: file_name.to_string(),
+            file_types: Some(vec![FileType::Binary]),
+            license_comments: None,
+            license_concluded: NOASSERTION.to_string(),
+            license_info_in_files: None,
+            notice_text: None,
+            spdxid,
+        })
+    }
+}
+
+/// Generate SHA1 and SHA256 checksums for a given file
+/// SPDX spec mandates SHA1
+fn calculate_checksums(path: &Utf8PathBuf) -> Result<Vec<FileChecksum>> {
+    let mut file = fs::File::open(path)?;
+    let mut sha256 = Sha256::new();
+    let sha1 = Sha1::new();
+    io::copy(&mut file, &mut sha256)?;
+    let sha256_hash = sha256.finalize();
+    let sha1_hash = sha1.finalize();
+    Ok(vec![
+        FileChecksum {
+            algorithm: Algorithm::Sha1,
+            checksum_value: hex::encode(&sha1_hash),
+        },
+        FileChecksum {
+            algorithm: Algorithm::Sha256,
+            checksum_value: hex::encode(&sha256_hash),
+        },
+    ])
 }

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -1,0 +1,118 @@
+//! Module for working with SPDX documents.
+
+use crate::git::get_current_user;
+use anyhow::{Context, Result};
+use cargo_metadata::camino::Utf8PathBuf;
+pub use schema::*;
+use sha1::{Digest, Sha1};
+use sha2::Sha256;
+use std::{fs, io};
+
+mod schema;
+
+pub const NOASSERTION: &str = "NOASSERTION";
+
+/// Build a new SPDX document builder based on collected information.
+pub fn builder(host_url: &str, output_file_name: &str) -> Result<DocumentBuilder> {
+    log::info!(target: "cargo_spdx", "building the document");
+
+    let mut builder = DocumentBuilder::default();
+    builder
+        .document_name(output_file_name)
+        .try_document_namespace(host_url)?
+        .creation_info(get_creation_info()?);
+    Ok(builder)
+}
+
+/// Identify the creator(s) of the SBOM.
+pub fn get_creation_info() -> Result<CreationInfo> {
+    let mut creator = vec![];
+
+    if let Ok(user) = get_current_user() {
+        creator.push(Creator::person(user.name, user.email));
+    }
+
+    creator.push(Creator::tool("cargo-spdx 0.1.0"));
+
+    Ok(CreationInfoBuilder::default().creators(creator).build()?)
+}
+
+impl From<&cargo_metadata::Package> for Package {
+    fn from(package: &cargo_metadata::Package) -> Self {
+        Package {
+            name: package.name.to_string(),
+            spdxid: format!("SPDXRef-{}-{}", package.name, package.version),
+            version_info: Some(package.version.to_string()),
+            package_file_name: None,
+            supplier: None,
+            originator: None,
+            download_location: NOASSERTION.to_string(),
+            files_analyzed: None,
+            package_verification_code: None,
+            checksums: None,
+            homepage: package.homepage.clone(),
+            source_info: None,
+            license_concluded: NOASSERTION.to_string(),
+            license_declared: NOASSERTION.to_string(),
+            copyright_text: NOASSERTION.to_string(),
+            description: None,
+            comment: None,
+            external_refs: Some(vec![ExternalRef {
+                reference_category: ReferenceCategory::PackageManager,
+                reference_type: "purl".to_string(),
+                reference_locator: format!("pkg:cargo/{}@{}", package.name, package.version),
+                comment: None,
+            }]),
+            annotations: None,
+            attribution_texts: None,
+            has_files: None,
+            license_comments: None,
+            license_info_from_files: None,
+            summary: None,
+        }
+    }
+}
+
+impl File {
+    pub fn try_from_binary(path: &Utf8PathBuf) -> Result<File> {
+        let file_name = path.file_name().unwrap();
+        let spdxid = format!("SPDXRef-File-{}", file_name);
+        Ok(File {
+            annotations: None,
+            attribution_texts: None,
+            checksums: Some(calculate_checksums(path)?),
+            comment: None,
+            copyright_text: NOASSERTION.to_string(),
+            file_contributors: None,
+            file_dependencies: None,
+            file_name: file_name.to_string(),
+            file_types: Some(vec![FileType::Binary]),
+            license_comments: None,
+            license_concluded: NOASSERTION.to_string(),
+            license_info_in_files: None,
+            notice_text: None,
+            spdxid,
+        })
+    }
+}
+
+/// Generate SHA1 and SHA256 checksums for a given file
+/// SPDX spec mandates SHA1
+fn calculate_checksums(path: &Utf8PathBuf) -> Result<Vec<FileChecksum>> {
+    let mut file = fs::File::open(path).context(format!("Failed to open {}", path))?;
+    let mut sha256 = Sha256::new();
+    let sha1 = Sha1::new();
+    io::copy(&mut file, &mut sha256)?;
+    let sha256_hash = sha256.finalize();
+    let sha1_hash = sha1.finalize();
+    Ok(vec![
+        FileChecksum {
+            algorithm: Algorithm::Sha1,
+            checksum_value: hex::encode(&sha1_hash),
+        },
+        FileChecksum {
+            algorithm: Algorithm::Sha256,
+            checksum_value: hex::encode(&sha256_hash),
+        },
+    ])
+}

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -21,7 +21,7 @@ pub enum Format {
 
 impl Format {
     /// Get the file extension for the format.
-    pub fn extension(&self) -> &'static str {
+    pub fn extension(self) -> &'static str {
         match self {
             Format::KeyValue => ".spdx",
             Format::Json => ".spdx.json",

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,13 +4,17 @@
 #![deny(missing_copy_implementations)]
 #![deny(missing_docs)]
 
-use crate::cargo::CrateMetadata;
+use crate::cargo::MetadataExt;
 use crate::cli::Args;
 use crate::format::Format;
 use crate::output::OutputManager;
 use anyhow::Result;
+use build::build;
+use cargo_metadata::MetadataCommand;
 use clap::Parser;
+use std::path::PathBuf;
 
+mod build;
 mod cargo;
 mod cli;
 mod document;
@@ -19,34 +23,41 @@ mod git;
 mod output;
 
 /// Program entrypoint, only inits the system, calls `run` and reports errors.
-fn main() {
-    init();
-
-    if let Err(e) = run() {
-        eprintln!("error: {}", e);
-    }
-}
-
-/// Initialize the context needed to run.
-fn init() {
+fn main() -> Result<()> {
     // Start the environment logger.
     env_logger::init();
-}
-
-/// Gathers CLI args, constructs an SPDX `Document`, and outputs that document.
-fn run() -> Result<()> {
-    // Load the CLI args and crate metadata, and then figure out where the SPDX file
-    // will be written, setting up a manager to ensure we only write when conditions are met.
     let args = Args::parse();
-    let metadata = CrateMetadata::load()?;
-    let output_manager = OutputManager::new(&args, metadata.root()?);
 
-    // Build the document.
-    let doc = document::build(
-        args.host_url()?.as_ref(),
-        &output_manager.output_file_name(),
-    )?;
+    // Invoke build subcommand if specified to run `cargo build` with added SBOMs
+    if let Some(cmd) = &args.subcommand {
+        match cmd {
+            cli::Command::Build { args: build_args } => {
+                build(build_args, args.host_url()?.as_ref(), args.format())?;
+            }
+        };
+    }
+    // Otherwise create an SBOM for the current workspace
+    else {
+        // Figure out where the SPDX file will be written, setting up a manager to ensure we only write when conditions are met.
+        let output_manager = if let Some(output) = args.output() {
+            // User specified a path, use that
+            OutputManager::new(output, args.force(), args.format())
+        } else {
+            // Determine path from metadata
+            let metadata = MetadataCommand::new().exec()?;
+            let path = PathBuf::from(format!(
+                "{}{}",
+                &metadata.root()?.name,
+                args.format().extension()
+            ));
+            OutputManager::new(&path, args.force(), args.format())
+        };
 
-    // Write the document to the output file.
-    output_manager.write_document(doc)
+        let doc = document::build(
+            args.host_url()?.as_ref(),
+            &output_manager.output_file_name(),
+        )?;
+        output_manager.write_document(&doc)?;
+    }
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,10 +53,11 @@ fn main() -> Result<()> {
             OutputManager::new(&path, args.force(), args.format())
         };
 
-        let doc = document::build(
+        let doc = document::builder(
             args.host_url()?.as_ref(),
             &output_manager.output_file_name(),
-        )?;
+        )?
+        .build()?;
         output_manager.write_document(&doc)?;
     }
     Ok(())


### PR DESCRIPTION
This adds a `cargo spdx build` subcommand that wraps `cargo build` and creates SBOMs for the produced binaries. The SBOMs are stored alongside the binary, with the same name + SPDX extension.

It uses the cargo's [json messages](https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages) to detect produced binaries and the dependencies produced in the build 

This approach also extends well to getting source file information outside of cargo: cargo's messages give info about rmeta files, which we can use to navigate to the dep-info files and get a list of the Rust source files.
The messages also tell us about build script execution, which we may be able to leverage for linking to non-Rust built code.

Usage
```
cargo spdx --format json -H 'https://foo.bar' build -- --all-features --message-format=json
```

The structs in `document.rs` were initially generated from the SPDX schema and tweaked (to configure serde to skip serializing optional fields if None).

The binary is added as a File information to the SBOM. All packages detected are also added, and a relationship between each package and the binary is added to show that binary depends on the package.

Various caveats of this first iteration:
1. Only supports executables (i.e bin target kinds, not dylib/cdylib/staticlib)
2. Package/file information is only output for JSON/yaml formats, until kv output support for those is added
3. `build` subcommand doesn't respect --force by design, but need to make that clearer through the UI. 