### PR TITLE
Add file information to SBOMs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,7 @@ dependencies = [
  "git2",
  "hex",
  "log",
+ "pathdiff",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -590,6 +591,15 @@ name = "os_str_bytes"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+dependencies = [
+ "camino",
+]
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ env_logger = "0.9.0"
 git2 = { version = "0.14.4", features = ["vendored-openssl", "vendored-libgit2"] }
 hex = "0.4.3"
 log = "0.4.17"
+pathdiff = { version = "0.2.1", features = ["camino"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 serde_yaml = "0.8.24"

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -16,3 +16,8 @@ impl<'a> MetadataExt<'a> for Metadata {
             .ok_or_else(|| anyhow!("no root found"))
     }
 }
+
+pub fn cargo_exec() -> String {
+    // cargo sets this for cargo subcommands, so use that when invoking cargo, if present
+    std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string())
+}

--- a/src/document/schema.rs
+++ b/src/document/schema.rs
@@ -1,5 +1,4 @@
 //! Defines the SPDX document structure.
-
 use anyhow::Result;
 use derive_builder::Builder;
 use derive_more::{Display, From};

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,14 @@ use crate::format::Format;
 use crate::output::OutputManager;
 use anyhow::Result;
 use build::build;
+use cargo::cargo_exec;
+use cargo_metadata::camino::Utf8PathBuf;
 use cargo_metadata::MetadataCommand;
 use clap::Parser;
+use document::{get_creation_info, DocumentBuilder, File, FileType, Package, Relationship};
+use std::io::BufRead;
 use std::path::PathBuf;
+use std::process::Command;
 
 mod build;
 mod cargo;
@@ -38,13 +43,14 @@ fn main() -> Result<()> {
     }
     // Otherwise create an SBOM for the current workspace
     else {
+        let metadata = MetadataCommand::new().exec()?;
+
         // Figure out where the SPDX file will be written, setting up a manager to ensure we only write when conditions are met.
         let output_manager = if let Some(output) = args.output() {
             // User specified a path, use that
             OutputManager::new(output, args.force(), args.format())
         } else {
             // Determine path from metadata
-            let metadata = MetadataCommand::new().exec()?;
             let path = PathBuf::from(format!(
                 "{}{}",
                 &metadata.root()?.name,
@@ -53,11 +59,74 @@ fn main() -> Result<()> {
             OutputManager::new(&path, args.force(), args.format())
         };
 
-        let doc = document::builder(
-            args.host_url()?.as_ref(),
-            &output_manager.output_file_name(),
-        )?
-        .build()?;
+        // Determine the files, package, and relationships for each
+        // member of the workspace
+        let mut packages = Vec::new();
+        let mut files = Vec::new();
+        let mut relationships = Vec::new();
+        for member in &metadata.workspace_members {
+            let package = &metadata[member];
+            // List files in package
+            let out = Command::new(&cargo_exec())
+                .args([
+                    "package",
+                    "--list",
+                    "--allow-dirty",
+                    "--manifest-path",
+                    package.manifest_path.as_str(),
+                ])
+                .output()?;
+            let root = package.manifest_path.parent().unwrap();
+            let mut source_files = out
+                .stdout
+                .lines()
+                .filter_map(Result::ok)
+                // `cargo package --list` includes the normalized Cargo.toml.orig
+                // but this won't be present locally (`cargo package` fails if it is)
+                // cargo package always lists Cargo.lock too, which may not be present.
+                // So just filter out any entries which can't be found locally
+                .filter_map(|path| {
+                    // Path is relative to crate root, so we need to add
+                    // the crate root in order to find it locally.
+                    let mut abs_path = Utf8PathBuf::from(root);
+                    abs_path.push(path);
+                    if abs_path.exists() {
+                        Some(abs_path)
+                    } else {
+                        None
+                    }
+                })
+                .map(|path| -> Result<File, anyhow::Error> {
+                    File::try_from_file(
+                        &path,
+                        root,
+                        FileType::Source,
+                        Some(&package.name),
+                        Some(&package.version.to_string()),
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let spdx_package: Package = package.into();
+            for file in &source_files {
+                relationships.push(Relationship {
+                    comment: None,
+                    related_spdx_element: file.spdxid.clone(),
+                    relationship_type: document::RelationshipType::Contains,
+                    spdx_element_id: spdx_package.spdxid.clone(),
+                });
+            }
+            packages.push(spdx_package);
+            files.append(&mut source_files);
+        }
+
+        let doc = DocumentBuilder::default()
+            .document_name(output_manager.output_file_name())
+            .try_document_namespace(args.host_url()?.as_ref())?
+            .creation_info(get_creation_info()?)
+            .files(files)
+            .packages(packages)
+            .relationships(relationships)
+            .build()?;
         output_manager.write_document(&doc)?;
     }
     Ok(())


### PR DESCRIPTION
Follows on from https://github.com/alilleybrinker/cargo-spdx/pull/9. Not worth reviewing this in detail until that's resolved.

Read the relevant rustc/cargo dep-info files to determine the source files used in the build. 
- For dependent libraries rustc produces an rmeta file and dep-info file. The rmeta file is included in the `cargo build` messages, and is used to navigate to the dep_info file
- For the binary, cargo outputs the dep-info file next to the binary: https://doc.rust-lang.org/cargo/guide/build-cache.html#dep-info-files
- 
These are then included in the SBOM relative to the owning package root, to avoid leaking any host specific paths into the SBOMs. A relationship is added between each file and its owning package, which is already a dependency of the binary from changes in https://github.com/alilleybrinker/cargo-spdx/pull/9.